### PR TITLE
#3 fixes template redirect on new cache

### DIFF
--- a/includes/class-airtable-api.php
+++ b/includes/class-airtable-api.php
@@ -103,7 +103,9 @@ class Airtable_Api
             return null;
         }
 
-        return set_transient(transient: $cache_key, value: $response['records'], expiration: self::CACHE_TTL);
+        set_transient(transient: $cache_key, value: $response['records'], expiration: self::CACHE_TTL);
+
+        return get_transient($cache_key);
     }
 
     /**


### PR DESCRIPTION
I was returning set_transient which is a bool, so it required a second call before the data was returned from the transients.